### PR TITLE
docs: mark repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
-# ymir-lb
+# ymir-lb-policy
 
-TODO: Enter the cookbook description here.
+> ## ⚠️ DEPRECATED — Archived and No Longer Maintained
+>
+> This repository is **deprecated**. It was last meaningfully updated in
+> 2020 and has been archived. It is preserved for historical reference only.
 
-  
+## Why this is deprecated
+
+This repo is part of a body of Chef/Jenkins/Policyfile work from the
+2018–2020 era that predates significant ecosystem changes:
+
+- Chef Software was acquired by Progress; Chef Infra licensing and
+  distribution changed in 2020–2021.
+- `knife`-based data bag workflows are considered legacy in favor of
+  Policyfile attributes.
+- Host-installed `chef-workstation` has largely been replaced by
+  containerized Chef tooling with pinned versions.
+- Chef Automate Workflow / Delivery has been discontinued.
+
+Do not use this repository as a reference for new work.
+
+## Status
+
+Archived. Issues and pull requests will not be reviewed.


### PR DESCRIPTION
Adds a deprecation notice to the README and prepares this repo for archival.